### PR TITLE
syntax: supporting older nodejs-versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,9 @@ var jsRTF = inherit(/** @lends jsRTF.prototype */{
      * @returns {String}
      */
     cascadeFormats : function (content, formats, params) {
-		if ( !params ) params = {};
+		if ( !params ) {
+			params = {};
+		}
         if ( !isArray(formats) ) {
             throw new Error('Formats must be an array!');
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,8 +82,8 @@ var jsRTF = inherit(/** @lends jsRTF.prototype */{
      * @param {Object} [params]
      * @returns {String}
      */
-    cascadeFormats : function (content, formats, params={}) {
-
+    cascadeFormats : function (content, formats, params) {
+		if ( !params ) params = {};
         if ( !isArray(formats) ) {
             throw new Error('Formats must be an array!');
         }


### PR DESCRIPTION
The "default parameter value" is a ES6 syntax, ie not supported by nodejs version below 6.
With this small change, I believe the library works fine on nodejs 4.8.2.